### PR TITLE
Agregar buscador a la lista de guardias

### DIFF
--- a/app/instalaciones/page.tsx
+++ b/app/instalaciones/page.tsx
@@ -1493,6 +1493,18 @@ export default function InstalacionesPage() {
                                 const guardiasDisponibles = guardias.filter(guardia => 
                                   guardia.estado === 'Activo' && !guardiasSeleccionados.includes(guardia.id.toString())
                                 )
+
+                                // Crear opciones para el SelectWithSearch
+                                const opcionesGuardias = [
+                                  {
+                                    value: 'sin-asignar',
+                                    label: '🟡 Sin asignar (genera PPC)'
+                                  },
+                                  ...guardiasDisponibles.map((guardia) => ({
+                                    value: guardia.id.toString(),
+                                    label: `🟢 ${guardia.nombre} - ${guardia.rut}${guardia.instalacion_id_name ? ` (${guardia.instalacion_id_name})` : ''}`
+                                  }))
+                                ]
                                 
                                 return (
                                   <div key={guardiaIndex} className="flex items-center gap-3 p-3 bg-background rounded-lg border">
@@ -1501,37 +1513,17 @@ export default function InstalacionesPage() {
                                         #{guardiaIndex + 1}
                                       </span>
                                       <div className="flex-1">
-                                        <Select
+                                        <SelectWithSearch
+                                          options={opcionesGuardias}
                                           value={guardiaAsignado.guardia_id?.toString() || 'sin-asignar'}
                                           onValueChange={(guardiaId) => {
                                             updateGuardiaAsignacion(index, guardiaIndex, guardiaId === 'sin-asignar' ? '' : guardiaId)
                                           }}
-                                        >
-                                          <SelectTrigger className="w-full">
-                                            <SelectValue placeholder="Seleccionar guardia" />
-                                          </SelectTrigger>
-                                          <SelectContent>
-                                            <SelectItem value="sin-asignar">
-                                              <div className="flex items-center gap-2">
-                                                <span className="w-2 h-2 rounded-full bg-yellow-500"></span>
-                                                Sin asignar (genera PPC)
-                                              </div>
-                                            </SelectItem>
-                                            {guardiasDisponibles.map((guardia) => (
-                                              <SelectItem key={guardia.id} value={guardia.id.toString()}>
-                                                <div className="flex items-center gap-2">
-                                                  <span className="w-2 h-2 rounded-full bg-green-500"></span>
-                                                  {guardia.nombre} - {guardia.rut}
-                                                  {guardia.instalacion_id_name && (
-                                                    <span className="text-xs text-muted-foreground">
-                                                      {' '}({guardia.instalacion_id_name})
-                                                    </span>
-                                                  )}
-                                                </div>
-                                              </SelectItem>
-                                            ))}
-                                          </SelectContent>
-                                        </Select>
+                                          placeholder="Seleccionar guardia"
+                                          searchPlaceholder="Buscar guardia por nombre o RUT..."
+                                          emptyMessage="No se encontraron guardias"
+                                          className="w-full"
+                                        />
                                       </div>
                                     </div>
                                     

--- a/components/GuardiaForm.tsx
+++ b/components/GuardiaForm.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { SelectWithSearch } from '@/components/ui/select-with-search'
 import { UbicacionAutocomplete } from '@/components/UbicacionAutocomplete'
 import { useAlertDialog } from '@/components/ui/alert-dialog'
 import { Loader2, X, MapPin } from 'lucide-react'
@@ -495,18 +496,18 @@ export function GuardiaForm({ open, onOpenChange, editData, onSuccess }: Guardia
                   <div className="grid grid-cols-1 gap-4">
                     <div>
                       <Label htmlFor="instalacion_id">Instalación *</Label>
-                      <Select value={formData.instalacion_id} onValueChange={(value) => handleInputChange('instalacion_id', value)}>
-                        <SelectTrigger className={errors.instalacion_id ? 'border-red-500' : ''}>
-                          <SelectValue placeholder="Seleccione una instalación" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {instalaciones.map((instalacion) => (
-                            <SelectItem key={instalacion.id} value={instalacion.id}>
-                              {instalacion.nombre}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <SelectWithSearch
+                        options={instalaciones.map((instalacion) => ({
+                          value: instalacion.id,
+                          label: instalacion.nombre
+                        }))}
+                        value={formData.instalacion_id}
+                        onValueChange={(value) => handleInputChange('instalacion_id', value)}
+                        placeholder="Seleccione una instalación"
+                        searchPlaceholder="Buscar instalación..."
+                        emptyMessage="No se encontraron instalaciones"
+                        className={errors.instalacion_id ? 'border-red-500' : ''}
+                      />
                       {errors.instalacion_id && <p className="text-sm text-red-500 mt-1">{errors.instalacion_id}</p>}
                     </div>
 
@@ -618,18 +619,18 @@ export function GuardiaForm({ open, onOpenChange, editData, onSuccess }: Guardia
                   <div className="grid grid-cols-1 gap-4">
                     <div>
                       <Label htmlFor="banco">Banco *</Label>
-                      <Select value={formData.banco_id} onValueChange={(value) => handleInputChange('banco_id', value)}>
-                        <SelectTrigger className={errors.banco_id ? 'border-red-500' : ''}>
-                          <SelectValue placeholder="Seleccione un banco" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {bancos.map((banco) => (
-                            <SelectItem key={banco.id} value={banco.id}>
-                              {banco.codigo} - {banco.nombre}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <SelectWithSearch
+                        options={bancos.map((banco) => ({
+                          value: banco.id,
+                          label: `${banco.codigo} - ${banco.nombre}`
+                        }))}
+                        value={formData.banco_id}
+                        onValueChange={(value) => handleInputChange('banco_id', value)}
+                        placeholder="Seleccione un banco"
+                        searchPlaceholder="Buscar banco por código o nombre..."
+                        emptyMessage="No se encontraron bancos"
+                        className={errors.banco_id ? 'border-red-500' : ''}
+                      />
                       {errors.banco_id && <p className="text-sm text-red-500 mt-1">{errors.banco_id}</p>}
                     </div>
 
@@ -652,35 +653,35 @@ export function GuardiaForm({ open, onOpenChange, editData, onSuccess }: Guardia
 
                     <div>
                       <Label htmlFor="salud">Salud *</Label>
-                      <Select value={formData.salud_id} onValueChange={(value) => handleInputChange('salud_id', value)}>
-                        <SelectTrigger className={errors.salud_id ? 'border-red-500' : ''}>
-                          <SelectValue placeholder="Seleccione sistema de salud" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {isapres.map((isapre) => (
-                            <SelectItem key={isapre.id} value={isapre.id}>
-                              {isapre.nombre}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <SelectWithSearch
+                        options={isapres.map((isapre) => ({
+                          value: isapre.id,
+                          label: isapre.nombre
+                        }))}
+                        value={formData.salud_id}
+                        onValueChange={(value) => handleInputChange('salud_id', value)}
+                        placeholder="Seleccione sistema de salud"
+                        searchPlaceholder="Buscar sistema de salud..."
+                        emptyMessage="No se encontraron sistemas de salud"
+                        className={errors.salud_id ? 'border-red-500' : ''}
+                      />
                       {errors.salud_id && <p className="text-sm text-red-500 mt-1">{errors.salud_id}</p>}
                     </div>
 
                     <div>
                       <Label htmlFor="afp">AFP *</Label>
-                      <Select value={formData.afp_id} onValueChange={(value) => handleInputChange('afp_id', value)}>
-                        <SelectTrigger className={errors.afp_id ? 'border-red-500' : ''}>
-                          <SelectValue placeholder="Seleccione AFP" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {afps.map((afp) => (
-                            <SelectItem key={afp.id} value={afp.id}>
-                              {afp.nombre}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <SelectWithSearch
+                        options={afps.map((afp) => ({
+                          value: afp.id,
+                          label: afp.nombre
+                        }))}
+                        value={formData.afp_id}
+                        onValueChange={(value) => handleInputChange('afp_id', value)}
+                        placeholder="Seleccione AFP"
+                        searchPlaceholder="Buscar AFP..."
+                        emptyMessage="No se encontraron AFPs"
+                        className={errors.afp_id ? 'border-red-500' : ''}
+                      />
                       {errors.afp_id && <p className="text-sm text-red-500 mt-1">{errors.afp_id}</p>}
                     </div>
                   </div>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add search functionality to guard selection dropdowns and other related entity selectors to improve usability.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The primary goal was to enable searching for guards by name, surname, and RUT in relevant dropdowns. This functionality was extended to other form selectors (installations, banks, health systems, AFPs) in `GuardiaForm` to provide a consistent and improved user experience when dealing with potentially long lists.

---

[Open in Web](https://cursor.com/agents?id=bc-628a8ede-78d1-488c-81cf-ceb2f900a1f5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-628a8ede-78d1-488c-81cf-ceb2f900a1f5) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)