### PR TITLE
Optimizar página PPC para móvil

### DIFF
--- a/app/ppc/page.tsx
+++ b/app/ppc/page.tsx
@@ -43,7 +43,9 @@ import {
   Users,
   FileText,
   CheckCircle,
-  XCircle
+  XCircle,
+  ChevronDown,
+  ChevronUp
 } from 'lucide-react'
 import { useToast } from '@/components/ui/toast'
 import { ToastContainer } from '@/components/ui/toast'
@@ -105,6 +107,10 @@ export default function PPCPage() {
   const [isAsignarGuardiaOpen, setIsAsignarGuardiaOpen] = useState(false)
   const [asignandoRegistro, setAsignandoRegistro] = useState<PPCRegistro | null>(null)
   const [selectedGuardiaId, setSelectedGuardiaId] = useState<string>('')
+  
+  // Estados para vista móvil
+  const [showFilters, setShowFilters] = useState(false)
+  const [expandedCard, setExpandedCard] = useState<string | null>(null)
   
   // Filtros
   const [filtros, setFiltros] = useState({
@@ -250,7 +256,7 @@ export default function PPCPage() {
   }
 
   const getEstadoBadge = (estado: string) => {
-    const baseClasses = "px-2 py-1 rounded-full text-xs font-medium"
+    const baseClasses = "px-3 py-1 rounded-full text-xs font-medium inline-flex items-center gap-1"
     switch (estado) {
       case 'pendiente':
         return `${baseClasses} bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200`
@@ -266,13 +272,13 @@ export default function PPCPage() {
   const getEstadoIcon = (estado: string) => {
     switch (estado) {
       case 'pendiente':
-        return <Clock className="h-4 w-4" />
+        return <Clock className="h-3 w-3" />
       case 'cubierto':
-        return <CheckCircle className="h-4 w-4" />
+        return <CheckCircle className="h-3 w-3" />
       case 'justificado':
-        return <FileText className="h-4 w-4" />
+        return <FileText className="h-3 w-3" />
       default:
-        return <XCircle className="h-4 w-4" />
+        return <XCircle className="h-3 w-3" />
     }
   }
 
@@ -352,40 +358,146 @@ export default function PPCPage() {
       fecha_desde: '',
       fecha_hasta: ''
     })
+    setShowFilters(false)
+  }
+
+  // Componente para tarjeta móvil de registro
+  const PPCCard = ({ registro }: { registro: PPCRegistro }) => {
+    const isExpanded = expandedCard === registro.id
+    
+    return (
+      <motion.div
+        className="mobile-card bg-card border rounded-xl p-4 shadow-sm"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        layout
+      >
+        {/* Header de la tarjeta */}
+        <div className="flex items-start justify-between gap-3 mb-3">
+          <div className="flex-1 min-w-0">
+            <h3 className="font-medium text-sm text-foreground truncate">
+              {registro.instalacion_id_name}
+            </h3>
+            <p className="text-xs text-muted-foreground mt-1 truncate">
+              {registro.puesto_operativo_id_name}
+            </p>
+          </div>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <span className={getEstadoBadge(registro.estado)}>
+              {getEstadoIcon(registro.estado)}
+              {registro.estado.charAt(0).toUpperCase() + registro.estado.slice(1)}
+            </span>
+          </div>
+        </div>
+
+        {/* Información básica */}
+        <div className="space-y-2 mb-3">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <MapPin className="h-3 w-3 flex-shrink-0" />
+            <span className="truncate">{registro.rol_servicio_id_name}</span>
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Calendar className="h-3 w-3 flex-shrink-0" />
+            <span>{new Date(registro.fecha_creacion).toLocaleDateString('es-ES')}</span>
+          </div>
+        </div>
+
+        {/* Botón para expandir/contraer */}
+        {registro.observaciones && (
+          <div className="mb-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setExpandedCard(isExpanded ? null : registro.id)}
+              className="h-auto p-2 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <FileText className="h-3 w-3 mr-1" />
+              {isExpanded ? 'Ocultar observaciones' : 'Ver observaciones'}
+              {isExpanded ? <ChevronUp className="h-3 w-3 ml-1" /> : <ChevronDown className="h-3 w-3 ml-1" />}
+            </Button>
+          </div>
+        )}
+
+        {/* Observaciones expandibles */}
+        {isExpanded && registro.observaciones && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            className="mb-3 p-3 bg-muted/50 rounded-lg"
+          >
+            <p className="text-xs text-foreground">{registro.observaciones}</p>
+          </motion.div>
+        )}
+
+        {/* Acciones */}
+        <div className="flex items-center gap-2 pt-2 border-t border-border/50">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handleEdit(registro)}
+            className="mobile-touch-button flex-1 text-xs gap-1"
+          >
+            <Edit className="h-3 w-3" />
+            Editar
+          </Button>
+          {registro.estado === 'pendiente' && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleAsignarGuardia(registro)}
+              className="mobile-touch-button flex-1 text-xs gap-1 text-green-600 border-green-200 hover:bg-green-50"
+            >
+              <Users className="h-3 w-3" />
+              Asignar
+            </Button>
+          )}
+        </div>
+      </motion.div>
+    )
   }
 
   return (
     <>
       <ToastContainer />
       
-      <div className="space-y-6">
+      <div className="space-y-4 md:space-y-6 px-4 md:px-0">
         {/* Header */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
         >
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-3xl font-bold capitalize-first flex items-center gap-3">
-                <AlertCircle className="h-8 w-8 text-primary" />
-                Personal de puesto de control (PPC)
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-2">
+              <h1 className="text-xl md:text-3xl font-bold capitalize-first flex items-center gap-2 md:gap-3">
+                <AlertCircle className="h-6 w-6 md:h-8 md:w-8 text-primary" />
+                <span className="leading-tight">Personal de puesto de control (PPC)</span>
               </h1>
-              <p className="text-muted-foreground mt-2">
+              <p className="text-sm md:text-base text-muted-foreground">
                 Gestión centralizada de puestos pendientes de cobertura
               </p>
             </div>
             
             <div className="flex items-center gap-2">
               <Button
+                onClick={() => setShowFilters(!showFilters)}
+                variant="outline"
+                size="sm"
+                className="md:hidden mobile-touch-button text-xs"
+              >
+                <Filter className="h-4 w-4 mr-1" />
+                Filtros
+              </Button>
+              <Button
                 onClick={handleRefresh}
                 disabled={isLoading}
                 variant="outline"
                 size="sm"
-                className="flex items-center gap-2"
+                className="mobile-touch-button text-xs md:text-sm gap-1 md:gap-2"
               >
                 <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
-                Actualizar
+                <span className="hidden sm:inline">Actualizar</span>
               </Button>
             </div>
           </div>
@@ -393,280 +505,296 @@ export default function PPCPage() {
 
         {/* Estadísticas */}
         <motion.div
-          className="grid grid-cols-1 md:grid-cols-5 gap-4"
+          className="grid grid-cols-2 md:grid-cols-5 gap-3 md:gap-4"
           initial={{ opacity: 0, scale: 0.95 }}
           animate={{ opacity: 1, scale: 1 }}
           transition={{ duration: 0.5, delay: 0.1 }}
         >
-          <div className="rounded-2xl border bg-card p-6 shadow-xl">
+          <div className="rounded-xl md:rounded-2xl border bg-card p-4 md:p-6 shadow-lg md:shadow-xl">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-muted-foreground">Total</p>
-                <p className="text-2xl font-bold">{estadisticas.total}</p>
+                <p className="text-xs md:text-sm font-medium text-muted-foreground">Total</p>
+                <p className="text-lg md:text-2xl font-bold">{estadisticas.total}</p>
               </div>
-              <Users className="h-8 w-8 text-blue-600" />
+              <Users className="h-6 w-6 md:h-8 md:w-8 text-blue-600" />
             </div>
           </div>
 
-          <div className="rounded-2xl border bg-card p-6 shadow-xl">
+          <div className="rounded-xl md:rounded-2xl border bg-card p-4 md:p-6 shadow-lg md:shadow-xl">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-muted-foreground">Pendientes</p>
-                <p className="text-2xl font-bold text-yellow-600">{estadisticas.pendientes}</p>
+                <p className="text-xs md:text-sm font-medium text-muted-foreground">Pendientes</p>
+                <p className="text-lg md:text-2xl font-bold text-yellow-600">{estadisticas.pendientes}</p>
               </div>
-              <Clock className="h-8 w-8 text-yellow-600" />
+              <Clock className="h-6 w-6 md:h-8 md:w-8 text-yellow-600" />
             </div>
           </div>
 
-          <div className="rounded-2xl border bg-card p-6 shadow-xl">
+          <div className="rounded-xl md:rounded-2xl border bg-card p-4 md:p-6 shadow-lg md:shadow-xl">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-muted-foreground">Cubiertos</p>
-                <p className="text-2xl font-bold text-green-600">{estadisticas.cubiertos}</p>
+                <p className="text-xs md:text-sm font-medium text-muted-foreground">Cubiertos</p>
+                <p className="text-lg md:text-2xl font-bold text-green-600">{estadisticas.cubiertos}</p>
               </div>
-              <CheckCircle className="h-8 w-8 text-green-600" />
+              <CheckCircle className="h-6 w-6 md:h-8 md:w-8 text-green-600" />
             </div>
           </div>
 
-          <div className="rounded-2xl border bg-card p-6 shadow-xl">
+          <div className="rounded-xl md:rounded-2xl border bg-card p-4 md:p-6 shadow-lg md:shadow-xl">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-muted-foreground">Justificados</p>
-                <p className="text-2xl font-bold text-blue-600">{estadisticas.justificados}</p>
+                <p className="text-xs md:text-sm font-medium text-muted-foreground">Justificados</p>
+                <p className="text-lg md:text-2xl font-bold text-blue-600">{estadisticas.justificados}</p>
               </div>
-              <FileText className="h-8 w-8 text-blue-600" />
+              <FileText className="h-6 w-6 md:h-8 md:w-8 text-blue-600" />
             </div>
           </div>
 
-          <div className="rounded-2xl border bg-card p-6 shadow-xl">
+          <div className="col-span-2 md:col-span-1 rounded-xl md:rounded-2xl border bg-card p-4 md:p-6 shadow-lg md:shadow-xl">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-muted-foreground">% Cobertura</p>
-                <p className="text-2xl font-bold text-primary">{estadisticas.porcentajeCubierto}%</p>
+                <p className="text-xs md:text-sm font-medium text-muted-foreground">% Cobertura</p>
+                <p className="text-lg md:text-2xl font-bold text-primary">{estadisticas.porcentajeCubierto}%</p>
               </div>
-              <AlertCircle className="h-8 w-8 text-primary" />
+              <AlertCircle className="h-6 w-6 md:h-8 md:w-8 text-primary" />
             </div>
           </div>
         </motion.div>
 
         {/* Filtros */}
         <motion.div
-          className="rounded-2xl border bg-card p-6 shadow-xl"
+          className={`rounded-xl md:rounded-2xl border bg-card shadow-lg md:shadow-xl overflow-hidden transition-all duration-300 ${
+            showFilters ? 'block' : 'hidden md:block'
+          }`}
           initial={{ opacity: 0, scale: 0.95 }}
           animate={{ opacity: 1, scale: 1 }}
           transition={{ duration: 0.5, delay: 0.2 }}
         >
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold flex items-center gap-2">
-              <Filter className="h-5 w-5" />
-              Filtros de búsqueda
-            </h3>
-            <Button variant="outline" size="sm" onClick={clearFiltros}>
-              Limpiar filtros
-            </Button>
-          </div>
-          
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <div className="space-y-2">
-              <Label>Instalación</Label>
-              <Select
-                value={filtros.instalacion_id}
-                onValueChange={(value) => setFiltros(prev => ({ ...prev, instalacion_id: value }))}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Todas las instalaciones" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Todas las instalaciones</SelectItem>
-                  {instalaciones.map((instalacion) => (
-                    <SelectItem key={instalacion.id} value={instalacion.id}>
-                      {instalacion.nombre}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+          <div className="p-4 md:p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-base md:text-lg font-semibold flex items-center gap-2">
+                <Filter className="h-4 w-4 md:h-5 md:w-5" />
+                Filtros de búsqueda
+              </h3>
+              <Button variant="outline" size="sm" onClick={clearFiltros} className="text-xs md:text-sm">
+                Limpiar filtros
+              </Button>
             </div>
+            
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-3 md:gap-4">
+              <div className="space-y-2">
+                <Label className="text-xs md:text-sm">Instalación</Label>
+                <Select
+                  value={filtros.instalacion_id}
+                  onValueChange={(value) => setFiltros(prev => ({ ...prev, instalacion_id: value }))}
+                >
+                  <SelectTrigger className="h-10 text-xs md:text-sm">
+                    <SelectValue placeholder="Todas las instalaciones" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Todas las instalaciones</SelectItem>
+                    {instalaciones.map((instalacion) => (
+                      <SelectItem key={instalacion.id} value={instalacion.id}>
+                        {instalacion.nombre}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
 
-            <div className="space-y-2">
-              <Label>Estado</Label>
-              <Select
-                value={filtros.estado}
-                onValueChange={(value) => setFiltros(prev => ({ ...prev, estado: value }))}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="todos">Todos los estados</SelectItem>
-                  <SelectItem value="pendiente">Pendiente</SelectItem>
-                  <SelectItem value="cubierto">Cubierto</SelectItem>
-                  <SelectItem value="justificado">Justificado</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+              <div className="space-y-2">
+                <Label className="text-xs md:text-sm">Estado</Label>
+                <Select
+                  value={filtros.estado}
+                  onValueChange={(value) => setFiltros(prev => ({ ...prev, estado: value }))}
+                >
+                  <SelectTrigger className="h-10 text-xs md:text-sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="todos">Todos los estados</SelectItem>
+                    <SelectItem value="pendiente">Pendiente</SelectItem>
+                    <SelectItem value="cubierto">Cubierto</SelectItem>
+                    <SelectItem value="justificado">Justificado</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
 
-            <div className="space-y-2">
-              <Label>Fecha desde</Label>
-              <Input
-                type="date"
-                value={filtros.fecha_desde}
-                onChange={(e) => setFiltros(prev => ({ ...prev, fecha_desde: e.target.value }))}
-              />
-            </div>
+              <div className="space-y-2">
+                <Label className="text-xs md:text-sm">Fecha desde</Label>
+                <Input
+                  type="date"
+                  value={filtros.fecha_desde}
+                  onChange={(e) => setFiltros(prev => ({ ...prev, fecha_desde: e.target.value }))}
+                  className="h-10 text-xs md:text-sm"
+                />
+              </div>
 
-            <div className="space-y-2">
-              <Label>Fecha hasta</Label>
-              <Input
-                type="date"
-                value={filtros.fecha_hasta}
-                onChange={(e) => setFiltros(prev => ({ ...prev, fecha_hasta: e.target.value }))}
-              />
+              <div className="space-y-2">
+                <Label className="text-xs md:text-sm">Fecha hasta</Label>
+                <Input
+                  type="date"
+                  value={filtros.fecha_hasta}
+                  onChange={(e) => setFiltros(prev => ({ ...prev, fecha_hasta: e.target.value }))}
+                  className="h-10 text-xs md:text-sm"
+                />
+              </div>
             </div>
           </div>
         </motion.div>
 
         {/* Content */}
         <motion.div
-          className="rounded-2xl border bg-card shadow-xl"
+          className="rounded-xl md:rounded-2xl border bg-card shadow-lg md:shadow-xl"
           initial={{ opacity: 0, scale: 0.95 }}
           animate={{ opacity: 1, scale: 1 }}
           transition={{ duration: 0.5, delay: 0.3 }}
         >
           {error ? (
-            <div className="p-8 text-center">
-              <h3 className="text-lg font-semibold text-destructive mb-2">Error al cargar datos</h3>
-              <p className="text-muted-foreground">{error}</p>
+            <div className="p-6 md:p-8 text-center">
+              <h3 className="text-base md:text-lg font-semibold text-destructive mb-2">Error al cargar datos</h3>
+              <p className="text-sm md:text-base text-muted-foreground">{error}</p>
             </div>
           ) : isLoading ? (
-            <div className="p-8 text-center">
+            <div className="p-6 md:p-8 text-center">
               <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent mx-auto mb-4" />
-              <p className="text-muted-foreground">Cargando registros PPC...</p>
+              <p className="text-sm md:text-base text-muted-foreground">Cargando registros PPC...</p>
             </div>
           ) : registros.length === 0 ? (
-            <div className="p-8 text-center">
-              <AlertCircle className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-              <h3 className="text-lg font-semibold mb-2">Sin registros PPC</h3>
-              <p className="text-muted-foreground mb-4">
+            <div className="p-6 md:p-8 text-center">
+              <AlertCircle className="h-10 w-10 md:h-12 md:w-12 text-muted-foreground mx-auto mb-4" />
+              <h3 className="text-base md:text-lg font-semibold mb-2">Sin registros PPC</h3>
+              <p className="text-sm md:text-base text-muted-foreground mb-4">
                 No hay registros de PPC que coincidan con los filtros aplicados
               </p>
             </div>
           ) : (
-            <div className="overflow-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="font-semibold">Instalación</TableHead>
-                    <TableHead className="font-semibold">Puesto operativo</TableHead>
-                    <TableHead className="font-semibold">Rol de servicio</TableHead>
-                    <TableHead className="font-semibold text-center">Estado</TableHead>
-                    <TableHead className="font-semibold text-center">Fecha creación</TableHead>
-                    <TableHead className="font-semibold">Observaciones</TableHead>
-                    <TableHead className="font-semibold text-center w-24">Acciones</TableHead>
-                  </TableRow>
-                </TableHeader>
-                
-                <TableBody>
-                  {registros.map((registro) => (
-                    <TableRow 
-                      key={registro.id} 
-                      className="hover:bg-muted/50 transition-colors"
-                    >
-                      <TableCell className="font-medium">{registro.instalacion_id_name}</TableCell>
-                      <TableCell>{registro.puesto_operativo_id_name}</TableCell>
-                      <TableCell>{registro.rol_servicio_id_name}</TableCell>
-                      <TableCell className="text-center">
-                        <div className="flex items-center justify-center gap-2">
-                          {getEstadoIcon(registro.estado)}
-                          <span className={getEstadoBadge(registro.estado)}>
-                            {registro.estado.charAt(0).toUpperCase() + registro.estado.slice(1)}
-                          </span>
-                        </div>
-                      </TableCell>
-                      <TableCell className="text-center text-sm text-muted-foreground">
-                        {new Date(registro.fecha_creacion).toLocaleDateString('es-ES')}
-                      </TableCell>
-                      <TableCell className="max-w-48 truncate">
-                        {registro.observaciones || '-'}
-                      </TableCell>
-                      <TableCell className="text-center">
-                        <div className="flex justify-center gap-1">
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => handleEdit(registro)}
-                            className="h-8 w-8 p-0"
-                            title="Editar estado"
-                          >
-                            <Edit className="h-4 w-4" />
-                          </Button>
-                          {registro.estado === 'pendiente' && (
+            <>
+              {/* Vista móvil: Tarjetas */}
+              <div className="md:hidden p-4 space-y-3">
+                {registros.map((registro) => (
+                  <PPCCard key={registro.id} registro={registro} />
+                ))}
+              </div>
+
+              {/* Vista desktop: Tabla */}
+              <div className="hidden md:block overflow-auto table-container">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="font-semibold">Instalación</TableHead>
+                      <TableHead className="font-semibold">Puesto operativo</TableHead>
+                      <TableHead className="font-semibold">Rol de servicio</TableHead>
+                      <TableHead className="font-semibold text-center">Estado</TableHead>
+                      <TableHead className="font-semibold text-center">Fecha creación</TableHead>
+                      <TableHead className="font-semibold">Observaciones</TableHead>
+                      <TableHead className="font-semibold text-center w-24">Acciones</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  
+                  <TableBody>
+                    {registros.map((registro) => (
+                      <TableRow 
+                        key={registro.id} 
+                        className="hover:bg-muted/50 transition-colors"
+                      >
+                        <TableCell className="font-medium">{registro.instalacion_id_name}</TableCell>
+                        <TableCell>{registro.puesto_operativo_id_name}</TableCell>
+                        <TableCell>{registro.rol_servicio_id_name}</TableCell>
+                        <TableCell className="text-center">
+                          <div className="flex items-center justify-center gap-2">
+                            {getEstadoIcon(registro.estado)}
+                            <span className={getEstadoBadge(registro.estado)}>
+                              {registro.estado.charAt(0).toUpperCase() + registro.estado.slice(1)}
+                            </span>
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-center text-sm text-muted-foreground">
+                          {new Date(registro.fecha_creacion).toLocaleDateString('es-ES')}
+                        </TableCell>
+                        <TableCell className="max-w-48 truncate">
+                          {registro.observaciones || '-'}
+                        </TableCell>
+                        <TableCell className="text-center">
+                          <div className="flex justify-center gap-1">
                             <Button
                               variant="ghost"
                               size="sm"
-                              onClick={() => handleAsignarGuardia(registro)}
-                              className="h-8 w-8 p-0 text-green-600 hover:text-green-800"
-                              title="Asignar guardia"
+                              onClick={() => handleEdit(registro)}
+                              className="h-8 w-8 p-0"
+                              title="Editar estado"
                             >
-                              <Users className="h-4 w-4" />
+                              <Edit className="h-4 w-4" />
                             </Button>
-                          )}
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
+                            {registro.estado === 'pendiente' && (
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleAsignarGuardia(registro)}
+                                className="h-8 w-8 p-0 text-green-600 hover:text-green-800"
+                                title="Asignar guardia"
+                              >
+                                <Users className="h-4 w-4" />
+                              </Button>
+                            )}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </>
           )}
         </motion.div>
       </div>
 
       {/* Formulario de edición */}
       <Dialog open={isFormOpen} onOpenChange={setIsFormOpen}>
-        <DialogContent className="max-w-lg">
+        <DialogContent className="max-w-lg mx-4 md:mx-auto max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle className="capitalize-first">
+            <DialogTitle className="capitalize-first text-base md:text-lg">
               Editar registro PPC
             </DialogTitle>
           </DialogHeader>
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="space-y-2">
-              <Label>Instalación</Label>
+              <Label className="text-sm">Instalación</Label>
               <Input 
                 value={selectedRegistro?.instalacion_id_name || ''} 
                 disabled 
-                className="bg-muted"
+                className="bg-muted text-sm h-10"
               />
             </div>
 
             <div className="space-y-2">
-              <Label>Puesto operativo</Label>
+              <Label className="text-sm">Puesto operativo</Label>
               <Input 
                 value={selectedRegistro?.puesto_operativo_id_name || ''} 
                 disabled 
-                className="bg-muted"
+                className="bg-muted text-sm h-10"
               />
             </div>
 
             <div className="space-y-2">
-              <Label>Rol de servicio</Label>
+              <Label className="text-sm">Rol de servicio</Label>
               <Input 
                 value={selectedRegistro?.rol_servicio_id_name || ''} 
                 disabled 
-                className="bg-muted"
+                className="bg-muted text-sm h-10"
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="estado">
+              <Label htmlFor="estado" className="text-sm">
                 Estado <span className="text-red-500">*</span>
               </Label>
               <Select 
                 value={formData.estado} 
                 onValueChange={(value) => setFormData(prev => ({ ...prev, estado: value as any }))}
               >
-                <SelectTrigger>
+                <SelectTrigger className="h-10 text-sm">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -678,21 +806,23 @@ export default function PPCPage() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="observaciones">Observaciones</Label>
+              <Label htmlFor="observaciones" className="text-sm">Observaciones</Label>
               <Input
                 id="observaciones"
                 value={formData.observaciones}
                 onChange={(e) => setFormData(prev => ({ ...prev, observaciones: e.target.value }))}
                 placeholder="Comentarios adicionales..."
+                className="text-sm h-10"
               />
             </div>
 
-            <DialogFooter className="gap-2">
+            <DialogFooter className="gap-2 flex-col md:flex-row">
               <Button 
                 type="button" 
                 variant="outline" 
                 onClick={() => setIsFormOpen(false)}
                 disabled={isSubmitting}
+                className="mobile-touch-button text-sm w-full md:w-auto"
               >
                 <X className="h-4 w-4 mr-2" />
                 Cancelar
@@ -700,6 +830,7 @@ export default function PPCPage() {
               <Button 
                 type="submit" 
                 disabled={isSubmitting}
+                className="mobile-touch-button text-sm w-full md:w-auto"
               >
                 {isSubmitting && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
                 <Save className="h-4 w-4 mr-2" />
@@ -712,9 +843,9 @@ export default function PPCPage() {
 
       {/* Modal para asignar guardia */}
       <Dialog open={isAsignarGuardiaOpen} onOpenChange={setIsAsignarGuardiaOpen}>
-        <DialogContent className="max-w-md">
+        <DialogContent className="max-w-md mx-4 md:mx-auto max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
+            <DialogTitle className="flex items-center gap-2 text-base md:text-lg">
               <Users className="h-5 w-5 text-green-600" />
               Asignar Guardia
             </DialogTitle>
@@ -722,34 +853,34 @@ export default function PPCPage() {
           
           <form onSubmit={handleSubmitAsignarGuardia} className="space-y-4">
             <div className="space-y-2">
-              <Label>Instalación</Label>
+              <Label className="text-sm">Instalación</Label>
               <Input 
                 value={asignandoRegistro?.instalacion_id_name || ''} 
                 disabled 
-                className="bg-muted"
+                className="bg-muted text-sm h-10"
               />
             </div>
 
             <div className="space-y-2">
-              <Label>Puesto operativo</Label>
+              <Label className="text-sm">Puesto operativo</Label>
               <Input 
                 value={asignandoRegistro?.puesto_operativo_id_name || ''} 
                 disabled 
-                className="bg-muted"
+                className="bg-muted text-sm h-10"
               />
             </div>
 
             <div className="space-y-2">
-              <Label>Rol de servicio</Label>
+              <Label className="text-sm">Rol de servicio</Label>
               <Input 
                 value={asignandoRegistro?.rol_servicio_id_name || ''} 
                 disabled 
-                className="bg-muted"
+                className="bg-muted text-sm h-10"
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="guardia">
+              <Label htmlFor="guardia" className="text-sm">
                 Seleccionar Guardia <span className="text-red-500">*</span>
               </Label>
               <SelectWithSearch
@@ -767,12 +898,13 @@ export default function PPCPage() {
               />
             </div>
 
-            <DialogFooter className="gap-2">
+            <DialogFooter className="gap-2 flex-col md:flex-row">
               <Button 
                 type="button" 
                 variant="outline" 
                 onClick={() => setIsAsignarGuardiaOpen(false)}
                 disabled={isSubmitting}
+                className="mobile-touch-button text-sm w-full md:w-auto"
               >
                 <X className="h-4 w-4 mr-2" />
                 Cancelar
@@ -780,7 +912,7 @@ export default function PPCPage() {
               <Button 
                 type="submit" 
                 disabled={isSubmitting || !selectedGuardiaId}
-                className="bg-green-600 hover:bg-green-700"
+                className="bg-green-600 hover:bg-green-700 mobile-touch-button text-sm w-full md:w-auto"
               >
                 {isSubmitting && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
                 <Users className="h-4 w-4 mr-2" />


### PR DESCRIPTION
Optimized the PPC page for mobile viewing to improve usability and responsiveness on small screens.

The previous layout, with its large data table and multi-column statistics grid, was not mobile-friendly. This PR introduces a responsive design, including a card-based layout for mobile, a 2-column grid for statistics, collapsible filters, and larger touch targets, ensuring a better user experience on smaller devices.

---

[Open in Web](https://cursor.com/agents?id=bc-5f347376-1e15-40d6-9191-5be9670c856c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5f347376-1e15-40d6-9191-5be9670c856c) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)