### PR TITLE
Corregir scroll en vista móvil

### DIFF
--- a/src/app/clientes/page.tsx
+++ b/src/app/clientes/page.tsx
@@ -533,8 +533,8 @@ export default function ClientesPage() {
         transition={{ duration: 0.5 }}
         className="space-y-6"
       >
-        {/* Barra de búsqueda, filtros y botón nuevo cliente - Fija al scroll */}
-        <Card className="bg-card/50 backdrop-blur-sm border-border/50 sticky top-0 z-10">
+        {/* Barra de búsqueda, filtros y botón nuevo cliente - Fija al scroll en desktop */}
+        <Card className="bg-card/50 backdrop-blur-sm border-border/50 lg:sticky lg:top-0 z-10">
           <CardContent className="p-4">
             <div className="flex flex-col gap-2">
               {/* Contador de registros */}
@@ -661,7 +661,7 @@ export default function ClientesPage() {
 
                 {/* Vista móvil - Cards */}
                 {isMobile && (
-                  <div className="grid gap-4">
+                  <div className="grid gap-4 pb-20">
                     {clientesFiltrados.map((cliente) => (
                       <ClienteCard key={cliente.id} cliente={cliente} />
                     ))}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -61,6 +61,30 @@
   html {
     @apply scroll-smooth;
   }
+
+  /* Mejoras para scrolling en móvil */
+  @media (max-width: 1024px) {
+    body {
+      /* Permitir scrolling natural en móvil */
+      overflow-x: hidden;
+      -webkit-overflow-scrolling: touch;
+      /* Mejorar el rendimiento de scroll en iOS */
+      transform: translateZ(0);
+    }
+    
+    /* Mejorar el comportamiento de touch en elementos interactivos */
+    * {
+      -webkit-tap-highlight-color: transparent;
+      /* Mejorar el scroll momentum en iOS */
+      -webkit-overflow-scrolling: touch;
+    }
+    
+    /* Asegurar que los elementos principales tengan scroll natural */
+    main {
+      -webkit-overflow-scrolling: touch;
+      overflow-y: auto;
+    }
+  }
 }
 
 @layer components {

--- a/src/app/instalaciones/page.tsx
+++ b/src/app/instalaciones/page.tsx
@@ -3,7 +3,7 @@ import { Building2, Plus } from "lucide-react";
 
 export default function InstalacionesPage() {
   return (
-    <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-700">
+    <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-700 min-h-screen lg:min-h-0">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-2xl font-bold heading-gradient">Gestión de Instalaciones</h2>

--- a/src/components/InstalacionesCliente.tsx
+++ b/src/components/InstalacionesCliente.tsx
@@ -100,7 +100,7 @@ export default function InstalacionesCliente({
           <p className="text-sm mt-1">Haz clic en &quot;Agregar Instalación&quot; para crear una nueva</p>
         </div>
       ) : (
-        <div className="space-y-3">
+        <div className="space-y-3 max-h-[50vh] lg:max-h-96 overflow-y-auto">
           {instalaciones.map((instalacion) => (
             <div
               key={instalacion.id}

--- a/src/components/layout/auth-wrapper.tsx
+++ b/src/components/layout/auth-wrapper.tsx
@@ -79,16 +79,16 @@ export function AuthWrapper({ children }: AuthWrapperProps) {
 
   // Para rutas privadas, mostrar el layout completo
   return (
-    <div className="flex h-screen bg-background">
+    <div className="flex min-h-screen bg-background lg:h-screen">
       {/* Sidebar */}
       <Sidebar className="hidden lg:flex lg:w-80 lg:flex-col" />
       
       {/* Main content */}
-      <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="flex-1 flex flex-col lg:overflow-hidden">
         <Navbar />
         
         {/* Page content */}
-        <main className="flex-1 overflow-auto">
+        <main className="flex-1 lg:overflow-auto">
           <div className="container mx-auto p-6 space-y-6">
             {children}
           </div>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -24,6 +24,7 @@ export function Sidebar({ className }: SidebarProps) {
 
   const toggleSidebar = () => {
     setIsOpen(!isOpen);
+    // No bloquear el scroll del body en móvil para el sidebar
   };
 
   return (

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -62,7 +62,7 @@ export function Modal({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center lg:items-center lg:justify-center p-4 lg:p-0">
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/50 backdrop-blur-sm"
@@ -72,7 +72,7 @@ export function Modal({
       {/* Modal */}
       <div
         className={cn(
-          "relative w-full mx-4 bg-background border border-border rounded-lg shadow-xl animate-in fade-in zoom-in-95 duration-200",
+          "relative w-full bg-background border border-border rounded-lg shadow-xl animate-in fade-in zoom-in-95 duration-200 max-h-[90vh] overflow-y-auto lg:max-h-none lg:overflow-visible",
           sizeClasses[size],
           className
         )}
@@ -100,7 +100,7 @@ export function Modal({
         )}
 
         {/* Content */}
-        <div className="p-6">
+        <div className="p-4 lg:p-6 overflow-y-auto">
           {children}
         </div>
       </div>


### PR DESCRIPTION
Enable natural mobile scrolling on client and installation pages.

The previous layout used fixed heights and `overflow-hidden` on main containers, combined with sticky headers and unoptimized modals, which prevented users from scrolling content on mobile devices. This PR adjusts these properties to allow proper touch-based scrolling.

---

[Open in Web](https://cursor.com/agents?id=bc-88926a35-b17c-4e14-8410-f0e2130d5b25) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-88926a35-b17c-4e14-8410-f0e2130d5b25) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)